### PR TITLE
Feature/subdirectories for zone files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ bind_lookup_zones: "{{inventory_dir}}/files/bind"
 # zonefiles as dict
 bind_zones: {}
 
+# subdirectory for zone files
+bind_config_subdirectories: False
+
 # create slave from master
 bind_create_slave_from_master: []
 
@@ -39,3 +42,4 @@ bind_acls: {}
 
 # List clients for dns64 in named.conf.options
 bind_dns64_clients: []
+

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -85,5 +85,6 @@
   template:
     src=build.slave.j2
     dest="{{bind_config_dir}}/named.conf.local.slave-{{item.master}}-{{item.limit_to|default(['all'])|join('-')}}"
+  notify: [restart bind]
   when: bind_create_slave_from_master is defined and bind_create_slave_from_master.0 is defined
   with_items: bind_create_slave_from_master

--- a/tasks/install.apt.yml
+++ b/tasks/install.apt.yml
@@ -8,3 +8,22 @@
     - bind9  
     - bind9utils
     - bind9-doc
+
+- name: Create subdirectory for slave zone files
+  file:
+    dest: "{{ bind_config_dir }}/master"
+    state: directory
+    owner: root
+    group: bind
+    mode: 02755
+  when: bind_config_subdirectories
+
+- name: Create subdirectory for slave zone files
+  file:
+    dest: "{{ bind_lib_dir }}/slave"
+    state: directory
+    owner: root
+    group: bind
+    mode: 0775
+  when: bind_config_subdirectories
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,6 +5,7 @@
 
 bind_config_dir: /etc/bind
 bind_cache_dir: /var/cache/bind
+bind_lib_dir: /var/lib/bind
 
 bind_user: bind
 bind_group: bind


### PR DESCRIPTION
To avoid cluttering the config files, this patch enables the creation and use of subdirectories for the zone files.